### PR TITLE
Removed all global variables from the interpreter.

### DIFF
--- a/src/compiler/compiler.c
+++ b/src/compiler/compiler.c
@@ -139,7 +139,7 @@ static void initCompiler(Compiler* compiler, Compiler* oldCompiler, VM* vm, Pars
 }
 
 static void emitByte(Parser* parser, Compiler* compiler, uint8_t byte) {
-	writeChunk(currentChunk(compiler), byte, parser->previous.line);
+	writeChunk(compiler->vm, currentChunk(compiler), byte, parser->previous.line);
 }
 
 static int emitJump(Parser* parser, Compiler* compiler, uint8_t instruction) {

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -3,9 +3,7 @@
 #include <vm/vm.h>
 #include <compiler/compiler.h>
 
-void* reallocate(void* pointer, size_t oldSize, size_t size);
-
-void setCurrentVMMemory(VM* vm); //TODO temp
+void* reallocate(VM* vm, void* pointer, size_t oldSize, size_t size);
 
 void collectGarbage(VM* vm);
 
@@ -15,10 +13,10 @@ void markValue(VM* vm, Value value);
 void markObject(VM* vm, Obj* object);
 void markTable(VM* vm, Table* table);
 
-#define ALLOCATE(type, count) \
-    (type*)reallocate(NULL, 0, sizeof(type) * (count))
+#define ALLOCATE(vm, type, count) \
+    (type*)reallocate(vm, NULL, 0, sizeof(type) * (count))
 
-#define GROW_ARRAY(type, pointer, oldSize, newSize) reallocate(pointer, sizeof(type) * (oldSize), sizeof(type) * (newSize))
+#define GROW_ARRAY(vm, type, pointer, oldSize, newSize) reallocate(vm, pointer, sizeof(type) * (oldSize), sizeof(type) * (newSize))
 
-#define FREE(type, pointer) reallocate(pointer, sizeof(type), 0)
-#define FREE_ARRAY(type, pointer, length) reallocate(pointer, sizeof(type) * (length), 0)
+#define FREE(vm, type, pointer) reallocate(vm, pointer, sizeof(type), 0)
+#define FREE_ARRAY(vm, type, pointer, length) reallocate(vm, pointer, sizeof(type) * (length), 0)

--- a/src/natives/globals.c
+++ b/src/natives/globals.c
@@ -8,7 +8,7 @@
 void defineNative(VM* vm, Table* table, const char* name, NativeFn function, size_t arity) {
 	push(vm, OBJ_VAL(copyString(vm, name, (int)strlen(name))));
 	push(vm, OBJ_VAL(newNative(vm, function, arity)));
-	tableSet(table, AS_STRING(vm->stack[0]), vm->stack[1]);
+	tableSet(vm, table, AS_STRING(vm->stack[0]), vm->stack[1]);
 	pop(vm);
 	pop(vm);
 }

--- a/src/natives/list.c
+++ b/src/natives/list.c
@@ -8,7 +8,7 @@ Value listLengthNative(VM* vm, size_t argCount, Value* args, bool* hasError) {
 }
 
 Value listAppendNative(VM* vm, size_t argCount, Value* args, bool* hasError) {
-	writeValueArray(&AS_LIST(args[0])->items, args[1]);
+	writeValueArray(vm, &AS_LIST(args[0])->items, args[1]);
 	return NULL_VAL;
 }
 

--- a/src/vm/chunk.c
+++ b/src/vm/chunk.c
@@ -10,29 +10,29 @@ void initChunk(Chunk* chunk) {
 	initValueArray(&chunk->constants);
 }
 
-void writeChunk(Chunk* chunk, uint8_t byte, size_t lineNumber) {
+void writeChunk(VM* vm, Chunk* chunk, uint8_t byte, size_t lineNumber) {
 
-	writeLineNumberTable(&chunk->table, chunk->count, lineNumber);
+	writeLineNumberTable(vm, &chunk->table, chunk->count, lineNumber);
 
 	if (chunk->capacity < chunk->count + 1) {
 		size_t oldCapacity = chunk->capacity;
 		chunk->capacity = chunk->capacity < 8 ? 8 : chunk->capacity * 2;
-		chunk->code = GROW_ARRAY(uint8_t, chunk->code, oldCapacity, chunk->capacity);
+		chunk->code = GROW_ARRAY(vm, uint8_t, chunk->code, oldCapacity, chunk->capacity);
 	}
 
 	chunk->code[chunk->count++] = byte;
 }
 
-void freeChunk(Chunk* chunk) {
-	FREE_ARRAY(uint8_t, chunk->code, chunk->capacity);
-	freeLineNumberTable(&chunk->table);
-	freeValueArray(&chunk->constants);
+void freeChunk(VM* vm, Chunk* chunk) {
+	FREE_ARRAY(vm, uint8_t, chunk->code, chunk->capacity);
+	freeLineNumberTable(vm, &chunk->table);
+	freeValueArray(vm, &chunk->constants);
 	initChunk(chunk);
 }
 
 size_t addConstant(VM* vm, Chunk* chunk, Value value) {
 	push(vm, value);
-	writeValueArray(&chunk->constants, value);
+	writeValueArray(vm, &chunk->constants, value);
 	pop(vm);
 	return chunk->constants.count - 1;
 }

--- a/src/vm/chunk.h
+++ b/src/vm/chunk.h
@@ -15,8 +15,8 @@ typedef struct {
 
 void initChunk(Chunk* chunk);
 
-void writeChunk(Chunk* chunk, uint8_t byte, size_t lineNumber);
+void writeChunk(VM* vm, Chunk* chunk, uint8_t byte, size_t lineNumber);
 
-void freeChunk(Chunk* chunk);
+void freeChunk(VM* vm, Chunk* chunk);
 
 size_t addConstant(VM* vm, Chunk* chunk, Value value);

--- a/src/vm/lineNumber.c
+++ b/src/vm/lineNumber.c
@@ -1,5 +1,6 @@
 #include "lineNumber.h"
 #include <core/memory.h>
+#include <vm/vm.h>
 #include <stdio.h>
 
 void initLineNumberTable(LineNumberTable* table) {
@@ -8,11 +9,11 @@ void initLineNumberTable(LineNumberTable* table) {
 	table->count = 0;
 }
 
-void writeLineNumberTable(LineNumberTable* table, size_t index, size_t line) {
+void writeLineNumberTable(VM* vm, LineNumberTable* table, size_t index, size_t line) {
 
 	if (table->count == 0) {
 		table->capacity = 8;
-		table->lines = GROW_ARRAY(size_t, table->lines, 0, table->capacity);
+		table->lines = GROW_ARRAY(vm, size_t, table->lines, 0, table->capacity);
 
 		table->lines[table->count] = index;
 		table->lines[table->count + 1] = line;
@@ -24,7 +25,7 @@ void writeLineNumberTable(LineNumberTable* table, size_t index, size_t line) {
 			if (table->capacity < table->count + 2) {
 				size_t oldCap = table->capacity;
 				table->capacity = table->capacity < 8 ? 8 : table->capacity * 2;
-				table->lines = GROW_ARRAY(size_t, table->lines, oldCap, table->capacity);
+				table->lines = GROW_ARRAY(vm, size_t, table->lines, oldCap, table->capacity);
 			}
 
 			table->lines[table->count] = index;
@@ -36,7 +37,7 @@ void writeLineNumberTable(LineNumberTable* table, size_t index, size_t line) {
 
 }
 
-void freeLineNumberTable(LineNumberTable* table) {
-	FREE_ARRAY(size_t, table->lines, table->capacity);
+void freeLineNumberTable(VM* vm, LineNumberTable* table) {
+	FREE_ARRAY(vm, size_t, table->lines, table->capacity);
 	initLineNumberTable(table);
 }

--- a/src/vm/lineNumber.h
+++ b/src/vm/lineNumber.h
@@ -6,8 +6,10 @@ typedef struct {
 	size_t* lines;
 } LineNumberTable;
 
+typedef struct VM VM;
+
 void initLineNumberTable(LineNumberTable* table);
 
-void writeLineNumberTable(LineNumberTable* table, size_t index, size_t line);
+void writeLineNumberTable(VM* vm, LineNumberTable* table, size_t index, size_t line);
 
-void freeLineNumberTable(LineNumberTable* table);
+void freeLineNumberTable(VM* vm, LineNumberTable* table);

--- a/src/vm/object.c
+++ b/src/vm/object.c
@@ -13,7 +13,7 @@
     (type*)allocateObject(vm, sizeof(type), objectType)
 
 Obj* allocateObject(VM* vm, size_t size, ObjType type) {
-	Obj* object = (Obj*)reallocate(NULL, 0, size);
+	Obj* object = (Obj*)reallocate(vm, NULL, 0, size);
 	object->type = type;
 	object->isMarked = false;
 	object->next = vm->objects;
@@ -33,7 +33,7 @@ static ObjString* allocateString(VM* vm, char* chars, size_t length, uint32_t ha
 	string->hash = hash;
 
 	push(vm, OBJ_VAL(string));
-	tableSet(&vm->strings, string, NULL_VAL);
+	tableSet(vm, &vm->strings, string, NULL_VAL);
 	pop(vm);
 
 	return string;
@@ -57,7 +57,7 @@ ObjString* takeString(VM* vm, char* chars, int length) {
 	ObjString* interned = tableFindString(&vm->strings, chars, length,
 		hash);
 	if (interned != NULL) {
-		FREE_ARRAY(char, chars, length + 1);
+		FREE_ARRAY(vm, char, chars, length + 1);
 		return interned;
 	}
 
@@ -71,7 +71,7 @@ ObjString* copyString(VM* vm, const char* chars, size_t length) {
 	ObjString* interned = tableFindString(&vm->strings, chars, length, hash);
 	if (interned != NULL) return interned;
 
-	char* heapChars = ALLOCATE(char, length + 1);
+	char* heapChars = ALLOCATE(vm, char, length + 1);
 	memcpy(heapChars, chars, length);
 	heapChars[length] = '\0';
 
@@ -96,7 +96,7 @@ ObjNative* newNative(VM* vm, NativeFn function, size_t arity) {
 }
 
 ObjClosure* newClosure(VM* vm, ObjFunction* function) {
-	ObjUpvalue** upvalues = ALLOCATE(ObjUpvalue*, function->upvalueCount);
+	ObjUpvalue** upvalues = ALLOCATE(vm, ObjUpvalue*, function->upvalueCount);
 	for (size_t i = 0; i < function->upvalueCount; i++) {
 		upvalues[i] = NULL;
 	}

--- a/src/vm/table.h
+++ b/src/vm/table.h
@@ -13,13 +13,15 @@ typedef struct {
 	Entry* entries;
 } Table;
 
+typedef struct VM VM;
+
 void initTable(Table* table);
 
-void freeTable(Table* table);
+void freeTable(VM* vm, Table* table);
 
-bool tableSet(Table* table, ObjString* key, Value value);
+bool tableSet(VM* vm, Table* table, ObjString* key, Value value);
 
-void tableAddAll(Table* from, Table* to);
+void tableAddAll(VM* vm, Table* from, Table* to);
 
 bool tableGet(Table* table, ObjString* key, Value* value);
 

--- a/src/vm/value.c
+++ b/src/vm/value.c
@@ -14,18 +14,18 @@ void initValueArray(ValueArray* array) {
 	array->count = 0;
 }
 
-void writeValueArray( ValueArray* array, Value value) {
+void writeValueArray(VM* vm, ValueArray* array, Value value) {
 	if (array->capacity < array->count + 1) {
 		size_t oldCap = array->capacity;
 		array->capacity = array->capacity < 8 ? 8 : array->capacity * 2;
-		array->values = GROW_ARRAY(Value, array->values, oldCap, array->capacity);
+		array->values = GROW_ARRAY(vm, Value, array->values, oldCap, array->capacity);
 	}
 
 	array->values[array->count++] = value;
 }
 
-void freeValueArray(ValueArray* array) {
-	FREE_ARRAY(Value, array->values, array->capacity);
+void freeValueArray(VM* vm, ValueArray* array) {
+	FREE_ARRAY(vm, Value, array->values, array->capacity);
 	initValueArray(array);
 }
 

--- a/src/vm/value.h
+++ b/src/vm/value.h
@@ -3,6 +3,7 @@
 
 typedef struct Obj Obj;
 typedef struct ObjString ObjString;
+typedef struct VM VM;
 
 typedef enum {
 	VAL_BOOL,
@@ -27,8 +28,8 @@ typedef struct {
 } ValueArray;
 
 void initValueArray(ValueArray* array);
-void writeValueArray(ValueArray* array, Value value);
-void freeValueArray(ValueArray* array);
+void writeValueArray(VM* vm, ValueArray* array, Value value);
+void freeValueArray(VM* vm, ValueArray* array);
 char* valueToString(Value value);
 bool isFalsey(Value value);
 bool valuesEqual(Value a, Value b);


### PR DESCRIPTION
In the previous version there were some global VM pointers, which would lead to crashes when imports and multithreading are added.