### PR TITLE
Added switch expressions

### DIFF
--- a/src/compiler/scanner.c
+++ b/src/compiler/scanner.c
@@ -297,6 +297,9 @@ Token scanToken(Scanner* scanner) {
 			else if (match(scanner, '-')) {
 				type = TOKEN_DECREMENT;
 			}
+			else if (match(scanner, '>')) {
+				type = TOKEN_ARROW;
+			}
 			return makeToken(scanner, type);
 		}
 


### PR DESCRIPTION
A switch clause can now be used as a part of an expression, returning an expression. The default value, if a path is not hit, is null.